### PR TITLE
[Cookiecloud] Use get method if body is empty

### DIFF
--- a/pkg/cookiecloud/cookiecloud.go
+++ b/pkg/cookiecloud/cookiecloud.go
@@ -134,16 +134,14 @@ func (c *Client) Get(ctx context.Context, req *GetReq) (*GetResp, error) {
 	)
 
 	// 云端解密
+	var method = resty.MethodGet
 	if req.CloudDecryption {
+		method = resty.MethodPost
 		cli = cli.SetBody(map[string]string{
 			"password": req.Password,
 		})
 	}
 
-	var method = resty.MethodGet
-	if req.CloudDecryption {
-		method = resty.MethodPost
-	}
 	var res, err = cli.SetResult(&resp).Execute(method, "/get/"+req.Uuid)
 
 	if err != nil {

--- a/pkg/cookiecloud/cookiecloud.go
+++ b/pkg/cookiecloud/cookiecloud.go
@@ -135,10 +135,17 @@ func (c *Client) Get(ctx context.Context, req *GetReq) (*GetResp, error) {
 
 	// 云端解密
 	if req.CloudDecryption {
-		cli = cli.SetBody(req)
+		cli = cli.SetBody(map[string]string{
+			"password": req.Password,
+		})
 	}
 
-	res, err := cli.SetResult(&resp).Post("/get/" + req.Uuid)
+	var method = resty.MethodGet
+	if req.CloudDecryption {
+		method = resty.MethodPost
+	}
+	var res, err = cli.SetResult(&resp).Execute(method, "/get/"+req.Uuid)
+
 	if err != nil {
 		return nil, fmt.Errorf("failed to request server: %v", err)
 	}
@@ -146,7 +153,7 @@ func (c *Client) Get(ctx context.Context, req *GetReq) (*GetResp, error) {
 		return nil, fmt.Errorf("uuid %s not found", req.Uuid)
 	}
 	if res.StatusCode() != 200 {
-		return nil, fmt.Errorf("server return status %d body %+V", res.StatusCode(), resp)
+		return nil, fmt.Errorf("server return status %d body %+v", res.StatusCode(), resp)
 	}
 	if req.CloudDecryption {
 		return &resp, nil

--- a/pkg/cookiecloud/cookiecloud_test.go
+++ b/pkg/cookiecloud/cookiecloud_test.go
@@ -123,7 +123,7 @@ func fakeServer(t *testing.T, now time.Time) *httptest.Server {
 			w.WriteHeader(http.StatusBadRequest)
 			return
 		}
-		if r.Method != http.MethodPost {
+		if r.Method != http.MethodPost && r.Method != http.MethodGet {
 			w.WriteHeader(http.StatusMethodNotAllowed)
 			return
 		}


### PR DESCRIPTION
## What
Using "GET" instead of "POST" when `CloudDecryption` is disabled

## Why
According to the [official API doc](https://github.com/easychen/CookieCloud/blob/master/README_cn.md#api-%E6%8E%A5%E5%8F%A3), `GET` and `POST` are both ok to download the cookie, However, `GET` would be more efficient if no body is needed to send.
Additionally, the popular third-party cookiecloud server implemented by MoviePilot only support `GET` method: https://github.com/jxxghp/MoviePilot/blob/52ce6ff38ed33ff12e3144deb0467ee12d015db7/app/api/servcookie.py#L117-L134

