### PR TITLE
Potential fix for code scanning alert no. 7: Size computation for allocation may overflow

### DIFF
--- a/pkg/cookie/punycode.go
+++ b/pkg/cookie/punycode.go
@@ -34,6 +34,9 @@ const (
 // The "while h < length(input)" line in the specification becomes "for
 // remaining != 0" in the Go code, because len(s) in Go is in bytes, not runes.
 func encode(prefix, s string) (string, error) {
+	if len(s) > (1<<31-1)/2 { // Ensure 2*len(s) does not overflow
+		return "", fmt.Errorf("input string is too large to encode")
+	}
 	output := make([]byte, len(prefix), len(prefix)+1+2*len(s))
 	copy(output, prefix)
 	delta, n, bias := int32(0), initialN, initialBias


### PR DESCRIPTION
Potential fix for [https://github.com/chaunsin/netease-cloud-music/security/code-scanning/7](https://github.com/chaunsin/netease-cloud-music/security/code-scanning/7)

To fix the issue, we need to ensure that the computation `2*len(s)` does not overflow. This can be achieved by validating the length of the input string `s` before performing the multiplication. If the length of `s` exceeds a safe threshold (e.g., half the maximum value of `int`), we should return an error to prevent the overflow.

Steps to implement the fix:
1. Add a check to ensure that `len(s)` is within a safe range before performing the multiplication.
2. If the length exceeds the safe range, return an error indicating that the input is too large.
3. Update the `encode` function in `pkg/cookie/punycode.go` to include this validation.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
